### PR TITLE
Correct broken links to easy-cla getting started.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ This repository contains a list of CLA documents for projects of the foundation
 
 CDF incorporates EasyCLA into various projects. The Contributor License Agreement (CLA) service of the Linux Foundation lets project contributors read, sign, and submit contributor license agreements easily.
 
-This platform supports both GitHub and Gerrit source code repositories. Additional information can be found in the [Getting Started Guide](https://github.com/communitybridge/easycla/blob/master/docs/getting-started.md).
+This platform supports both GitHub and Gerrit source code repositories. Additional information can be found in the [Getting Started Guide](https://github.com/communitybridge/easycla/tree/master/getting-started).
 
 * https://github.com/communitybridge/easycla
-* https://github.com/communitybridge/easycla/blob/master/docs/getting-started.md
+* https://github.com/communitybridge/easycla/tree/master/getting-started
 
 
 ### Projects


### PR DESCRIPTION
Correct broken links to easy-cla getting started.